### PR TITLE
Remove source images after sprite page is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ metalsmith(__dirname)
 `spritesmith`: Options that will be passed to `spritesmith.processImages`
 
 `templater`: Options for spritesmith templater
+
+`removeSrc`: Remove input files after sprite creation

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function metalsmith_spritesmith(options) {
   options = options || {};
   options.templater = options.templater || {};
   options.spritesmith = options.spritesmith || {};
+  options.removeSrc = options.removeSrc || false;
 
   if(!options.src) {
     done(new Error('Metalsmith-Spritesmith missing required parameter: src'));
@@ -68,6 +69,10 @@ module.exports = function metalsmith_spritesmith(options) {
         };
         done();
       });
+
+      if(options.removeSrc){
+        Object.keys(result.coordinates).forEach((file) => {delete files[file.slice(4)];});
+      }
 
     });
   };


### PR DESCRIPTION
Added setting called `removeSrc` which will remove source images after the sprite page has been created.
